### PR TITLE
fix: Cleanup dangling images on remote server

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,8 +16,8 @@ rsync -r --delete-after --quiet \
 # Entering the server
 ssh "$SSH_USER@$SSH_HOST" <<EOF
   cd /app/frontend
-  docker image build --tag vuttr-frontend:latest --no-cache .
+  docker image build --tag vuttr-frontend .
+  if [[ $(docker container ps -qa -f 'name=vuttr-frontend') ]]; then docker container rm -f vuttr-frontend; fi
+  docker container run --name vuttr-frontend -d -p 8080:80 vuttr-frontend
   if [[ $(docker images -qa -f 'dangling=true') ]]; then docker image rm $(docker images -qa -f 'dangling=true'); fi
-  if [[ $(docker container ps -qa -f 'name=vuttr-frontend' -f 'status=running') ]]; then docker container rm -f vuttr-frontend; fi
-  docker container run --name vuttr-frontend -d -p 8080:80 vuttr-frontend:latest
 EOF


### PR DESCRIPTION
When build a new docker image and running container script clean
the dangling images