### PR TITLE
fix: Update deploy script to use bash

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,10 +14,12 @@ rsync -r --delete-after --quiet \
   $TRAVIS_BUILD_DIR/ "$SSH_USER@$SSH_HOST":/app/frontend
 
 # Entering the server
-ssh "$SSH_USER@$SSH_HOST" <<EOF
+ssh "$SSH_USER@$SSH_HOST" /bin/bash <<'EOF'
   cd /app/frontend
   docker image build --tag vuttr-frontend .
-  if [[ $(docker container ps -qa -f 'name=vuttr-frontend') ]]; then docker container rm -f vuttr-frontend; fi
+  CONTAINER=$(docker container ps -qa -f 'name=vuttr-frontend')
+  DANGLING_IMAGES=$(docker images -qa -f 'dangling=true')
+  if [[ $CONTAINER ]]; then docker container rm -f $CONTAINER; fi
   docker container run --name vuttr-frontend -d -p 8080:80 vuttr-frontend
-  if [[ $(docker images -qa -f 'dangling=true') ]]; then docker image rm $(docker images -qa -f 'dangling=true'); fi
+  if [[ $DANGLING_IMAGES ]]; then docker image rm $DANGLING_IMAGES; fi
 EOF


### PR DESCRIPTION
The deploy script was not using the bash shell to execute the commands,
resulting in deploy errors.

[ci skip]